### PR TITLE
Switch double-conversion for blaze-textual.

### DIFF
--- a/bytestring-conversion.cabal
+++ b/bytestring-conversion.cabal
@@ -41,7 +41,7 @@ library
       , attoparsec        >= 0.10   && < 1.0
       , bytestring        >= 0.10.4 && < 1.0
       , case-insensitive  >= 1.2    && < 2.0
-      , double-conversion >= 2.0    && < 3.0
+      , blaze-textual     >= 0.2    && < 0.3
       , text              >= 0.11   && < 2.0
 
 test-suite bytestring-conversion-tests

--- a/bytestring-conversion.cabal
+++ b/bytestring-conversion.cabal
@@ -41,9 +41,14 @@ library
       , attoparsec        >= 0.10   && < 1.0
       , bytestring        >= 0.10.4 && < 1.0
       , case-insensitive  >= 1.2    && < 2.0
-      , blaze-textual     >= 0.2    && < 0.3
       , text              >= 0.11   && < 2.0
 
+    if os(windows)
+      build-depends: blaze-textual     >= 0.2 && < 0.3
+      cpp-options: -DWIN
+    else
+      build-depends: double-conversion >= 2.0 && < 3.0
+     
 test-suite bytestring-conversion-tests
     type:             exitcode-stdio-1.0
     default-language: Haskell2010

--- a/src/Data/ByteString/Conversion/To.hs
+++ b/src/Data/ByteString/Conversion/To.hs
@@ -4,6 +4,7 @@
 
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 module Data.ByteString.Conversion.To
@@ -30,8 +31,11 @@ import qualified Data.ByteString.Lazy    as L
 import qualified Data.Text               as T
 import qualified Data.Text.Lazy          as TL
 import qualified Data.Text.Lazy.Encoding as TL
+#ifdef WIN
 import           Blaze.Text.Double
-
+#else
+import           Data.Double.Conversion.Text
+#endif
 class ToByteString a where
     builder :: a -> Builder
 
@@ -42,8 +46,13 @@ instance ToByteString Text         where builder x = byteString $ encodeUtf8 x
 instance ToByteString TL.Text      where builder x = lazyByteString $ TL.encodeUtf8 x
 instance ToByteString Char         where builder x = builder $ T.singleton x
 instance ToByteString [Char]       where builder x = builder $ TL.pack x
+#ifdef WIN
 instance ToByteString Float        where builder x = double $ float2Double x
 instance ToByteString Double       where builder x = double x
+#else
+instance ToByteString Float        where builder x = builder $ toShortest $ float2Double x
+instance ToByteString Double       where builder x = builder $ toShortest x
+#endif
 
 instance ToByteString Int          where builder x = intDec x
 instance ToByteString Int8         where builder x = int8Dec x

--- a/src/Data/ByteString/Conversion/To.hs
+++ b/src/Data/ByteString/Conversion/To.hs
@@ -18,7 +18,6 @@ import Data.ByteString.Conversion.Internal
 import Data.ByteString.Lazy.Builder
 import Data.ByteString.Lazy.Builder.Extras hiding (runBuilder)
 import Data.CaseInsensitive (CI, original)
-import Data.Double.Conversion.Text
 import Data.Int
 import Data.List (intersperse)
 import Data.Monoid
@@ -31,6 +30,7 @@ import qualified Data.ByteString.Lazy    as L
 import qualified Data.Text               as T
 import qualified Data.Text.Lazy          as TL
 import qualified Data.Text.Lazy.Encoding as TL
+import           Blaze.Text.Double
 
 class ToByteString a where
     builder :: a -> Builder
@@ -42,8 +42,8 @@ instance ToByteString Text         where builder x = byteString $ encodeUtf8 x
 instance ToByteString TL.Text      where builder x = lazyByteString $ TL.encodeUtf8 x
 instance ToByteString Char         where builder x = builder $ T.singleton x
 instance ToByteString [Char]       where builder x = builder $ TL.pack x
-instance ToByteString Float        where builder x = builder $ toShortest $ float2Double x
-instance ToByteString Double       where builder x = builder $ toShortest x
+instance ToByteString Float        where builder x = double $ float2Double x
+instance ToByteString Double       where builder x = double x
 
 instance ToByteString Int          where builder x = intDec x
 instance ToByteString Int8         where builder x = int8Dec x


### PR DESCRIPTION
Hi,

The double-conversion package, while providing excellent performance,
unfortunately has some issues with GHCi and under windows (see, for
example, https://github.com/bos/blaze-textual#readme).

For this reason, the blaze-textual package offers the option to fall
back on native conversion, trading speed for stability. Instead of
replicating this option here, I thought it best to depend on
blaze-textual instead. The choice between the native code and
double-conversion can then be made via the native flag of the
blaze-textual library.

What do you think?
Best,
Philipp